### PR TITLE
layer-based half-light.js

### DIFF
--- a/half-light.js
+++ b/half-light.js
@@ -20,7 +20,7 @@ function refreshTargetedStyles() {
 
           let where = (f && f.length == 2 && f[1]) ? f[1] : '*'
           targetedStyles[where] = targetedStyles[where] || new CSSStyleSheet();
-          targetedStyles[where].insertRule(innerRule.cssText)
+          targetedStyles[where].insertRule('@layer {' + innerRule.cssText + '}')
         })
       }
     })


### PR DESCRIPTION
This is a deeply ungratifying way to solve this problem, but this would wrap each rule in `@layer` so that it worked more or less like a UA stylesheet for the shadow root (I think).. _More_ similar to (better than) how it was before introducing adopted stylesheets -- adopted stylesheets from #2 makes it weird because those come after `<style>` in the shadow root (I think).

