### PR TITLE
Possible optimzations

### DIFF
--- a/half-light.js
+++ b/half-light.js
@@ -33,7 +33,7 @@
   function refreshTargetedStyles() {
     targetedStyles = [];
     [...document.styleSheets].forEach((sheet) => {
-      if (!sheet.ownerNode.matches("head > *")) return;
+      if (!sheet.ownerNode.matches("head > :not([no-half-light])")) return;
 
       let sheetMQResult = parseMQ(sheet.media.mediaText);
       if (sheetMQResult.isCrossRoot) { 
@@ -91,6 +91,13 @@
     });
   })
   
+  let script = document.currentScript;
+  document.addEventListener("DOMContentLoaded", () => {
+    if(script.hasAttribute('disable-live-half-light')) {
+      observer.disconnect()
+    }
+  })
+
   let old = Element.prototype.attachShadow;
   Element.prototype.attachShadow = function () {
     let r = old.call(this, ...arguments);

--- a/half-light.js
+++ b/half-light.js
@@ -92,7 +92,7 @@
   })
   
   let script = document.currentScript;
-  let liveEnabled = false;
+  let liveEnabled = true;
   document.addEventListener("DOMContentLoaded", () => {
     if(script.hasAttribute('disable-live-half-light')) {
       observer.disconnect()

--- a/half-light.js
+++ b/half-light.js
@@ -92,10 +92,12 @@
   })
   
   let script = document.currentScript;
+  let liveEnabled = false;
   document.addEventListener("DOMContentLoaded", () => {
     if(script.hasAttribute('disable-live-half-light')) {
       observer.disconnect()
       openStylableElements.clear()
+      liveEnabled = false
     }
   })
 
@@ -107,7 +109,9 @@
       if (isInDarkRoot(r)) {
         return;
       }
-      openStylableElements.add(this);
+      if (liveEnabled) {
+        openStylableElements.add(this);
+      }
       __alreadyAdopted.set(
         this,
         Array.from(this.shadowRoot.adoptedStyleSheets)

--- a/half-light.js
+++ b/half-light.js
@@ -95,6 +95,7 @@
   document.addEventListener("DOMContentLoaded", () => {
     if(script.hasAttribute('disable-live-half-light')) {
       observer.disconnect()
+      openStylableElements.clear()
     }
   })
 


### PR DESCRIPTION
Based on some feedback from discord and in #13, this would allow opting out of live mutation observation and out of processing sheets - _as an optimization_ (not required)

If an author would add the `no-half-light` attribute (as in `<style no-half-light>`), then processing of the rules in that stylesheet by half-light will be skipped.

If an author puts the `disable-live-half-light` attribute on the script they use to include half-light (as in `<script src="half-light" disable-live-half-light></script>`), then changes to styles in the head after `DOMContentLoaded` will not be updated live/accounted for.

The latter feels to me like a kind of weak optimization though - moving that recently to use rAF seems like a bigger optimization as it just skips the sort of potentially heavy as the head of the document is still parsing inefficiencies. Continuing to observe the head after that is pretty low cost, I'd guess, and keeps it working even with dev tools which is really nice /@sorvell